### PR TITLE
Remove broken lazy-initialization pattern for MathConsts

### DIFF
--- a/Geodesy/UtmProjection.cs
+++ b/Geodesy/UtmProjection.cs
@@ -28,6 +28,7 @@ namespace Geodesy
         public UtmProjection(Ellipsoid referenceGlobe)
             : base(referenceGlobe)
         {
+            _m = new MathConsts(referenceGlobe);
         }
 
         public override Angle MinLatitude
@@ -45,9 +46,6 @@ namespace Geodesy
             out double scaleFactor,
             out double meridianConvergence)
         {
-            if (M == null)
-                throw new Exception();
-
             var grid = new UtmGrid(this, coordinates);
 
             var northingOffset = grid.IsNorthern ? 0.0 : 10000000.0;
@@ -245,17 +243,6 @@ namespace Geodesy
         }
 
         private MathConsts _m;
-
-        private MathConsts M
-        {
-            get
-            {
-                if (_m != null)
-                    return _m;
-                _m = new MathConsts(ReferenceGlobe);
-                return _m;
-            }
-        }
 
         private static double Atanh(double x)
         {


### PR DESCRIPTION
Any call to FromEuclidean method would fail unless a previous call to
ToEuclidean is executed, as private _m fields was only properly
initialized when ToEuclidean was called.
The content of MathConsts doesn't seem to be so time-consuming or use so
much memory to require a lazy-initialization pattern, so I directly
instantiated the MathConsts in _m field in the constructor.
