### PR TITLE
fix validation on GlobalMesh to accept mesh size of 1m or above

### DIFF
--- a/Geodesy/GlobalMesh.cs
+++ b/Geodesy/GlobalMesh.cs
@@ -34,7 +34,7 @@ namespace Geodesy
         /// <exception cref="ArgumentOutOfRangeException">Raised if an invalid mesh size is specified</exception>
         public GlobalMesh(int meshSizeinMeters = 1000)
         {
-            if (meshSizeinMeters <= MinimumMeshSize)
+            if (meshSizeinMeters < MinimumMeshSize)
                 throw new ArgumentOutOfRangeException(Resources.MESHSIZE_MIN_VIOLATION);
             
             MeshSize = meshSizeinMeters;

--- a/UnitTestGeodesy/TestGlobalMesh.cs
+++ b/UnitTestGeodesy/TestGlobalMesh.cs
@@ -1,6 +1,8 @@
 ﻿/* See License.md in the solution root for license information.
  * File: TestGlobalMesh.cs
 */
+
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Geodesy;
 
@@ -50,6 +52,35 @@ namespace UnitTestGeodesy
             Assert.AreEqual(n2.Count,16);
             var n3 = theMesh.Neighborhood(nr, 3);
             Assert.AreEqual(n3.Count,24);
+        }
+
+        [TestMethod]
+        public void TestMeshSizeInMetersValidation()
+        {
+            try
+            {
+                new GlobalMesh(0);
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                new GlobalMesh(1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                Assert.Fail();
+            }
+
+            try
+            {
+                new GlobalMesh(2);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                Assert.Fail();
+            }
         }
     }
 }


### PR DESCRIPTION
A small change to GlobalMesh and unit test to ensure that we allow mesh sizes that are equal to the minimum size